### PR TITLE
fix console warning for prop "options"

### DIFF
--- a/src/components/vue-mathjax.vue
+++ b/src/components/vue-mathjax.vue
@@ -14,7 +14,7 @@ export default {
     },
     options: {
       type: Object,
-      default: {}
+      default: function(){ return {} }
     }
   },
   watch: {


### PR DESCRIPTION
There is warning "Props with type Object/Array must use a factory function to return the default value" in console.