### PR TITLE
Set paren-based math mode delimiters correctly

### DIFF
--- a/src/components/vue-mathjax.vue
+++ b/src/components/vue-mathjax.vue
@@ -41,8 +41,8 @@ export default {
       if (window.MathJax) {
         window.MathJax.Hub.Config({
           tex2jax: {
-            inlineMath: [['$', '$'], ['(', ')']],
-            displayMath: [['$$', '$$'], ['[', ']']],
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            displayMath: [['$$', '$$'], ['\\[', '\\]']],
             processEscapes: true,
             processEnvironments: true
           },


### PR DESCRIPTION
As is, if you include MathJax and write anything inbetween parentheses or square brackets, MathJax will treat it as a math mode block. This change sets it to use `\( \)` and `\[ \]` instead (although I still think it's problematic that you can write stuff outside of `<vue-mathjax/>` elements that will be rendered as LaTeX, but I'm not sure how/if that's fixable).

An example of the wrong behaviour I'm describing:

```js
<p>
  ... (hopefully) be ...
</p>
```
gets rendered as

![image](https://user-images.githubusercontent.com/22411874/97179503-2e59bc00-1799-11eb-8155-421b547da5aa.png)

because it's recognized as an inline math block.

After applying my changes, it only happens if I write

```js
<p>
  ... \(hopefully\) be ...
</p>
```
(I still think this last part shouldn't happen, but I'm not sure how to disable it)