### PR TITLE
Update vue-mathjax.vue

### DIFF
--- a/src/components/vue-mathjax.vue
+++ b/src/components/vue-mathjax.vue
@@ -41,7 +41,7 @@ export default {
       if (window.MathJax) {
         window.MathJax.Hub.Config({
           tex2jax: {
-            inlineMath: [['$', '$'], ['(', ')']],
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
             displayMath: [['$$', '$$'], ['[', ']']],
             processEscapes: true,
             processEnvironments: true


### PR DESCRIPTION
The standard TeX tags are `\(`, `\)`, as opposed to just `(` `)`. I think this might have been an oversight.